### PR TITLE
GitHub Grouping log lines

### DIFF
--- a/Tests/XSToolingTests/Core/ProcessCommandTests.swift
+++ b/Tests/XSToolingTests/Core/ProcessCommandTests.swift
@@ -32,7 +32,7 @@ final class ProcessCommandTests: GHTestCase {
     }
 
     func testRunWithRedirection() async throws {
-        let command = ProcessCommand.bash("echo 'test'")
+        let command = ProcessCommand.bash("echo 'test fail'")
 
         let output = try await command.run(.output(.standardOutput).error(.standardOutput))
 

--- a/Tests/XSToolingTests/GHTest/GHActions.swift
+++ b/Tests/XSToolingTests/GHTest/GHActions.swift
@@ -12,6 +12,14 @@ struct GHActions {
     func error(message: String) {
         print("::error::\(message)")
     }
+
+    func group(_ name: String) {
+        print("::group::\(name)")
+    }
+
+    func endGroup() {
+        print("::endgroup::")
+    }
 }
 
 extension GHActions {

--- a/Tests/XSToolingTests/GHTest/GHTestCase.swift
+++ b/Tests/XSToolingTests/GHTest/GHTestCase.swift
@@ -8,7 +8,7 @@
 import XCTest
 
 class GHTestCase: XCTestCase {
-    var github: GHActions { .shared }
+    var github: GHActions = .shared
 
     var isLinux: Bool {
 #if os(Linux)
@@ -16,6 +16,12 @@ class GHTestCase: XCTestCase {
 #else
         return false
 #endif
+    }
+
+    override func run() {
+        github.group(name)
+        super.run()
+        github.endGroup()
     }
 
 #if os(Linux)

--- a/Tests/XSToolingTests/GHTest/GHTestCase.swift
+++ b/Tests/XSToolingTests/GHTest/GHTestCase.swift
@@ -18,16 +18,6 @@ class GHTestCase: XCTestCase {
 #endif
     }
 
-    override class func setUp() {
-        GHActions.shared.group(defaultTestSuite.name)
-        super.setUp()
-    }
-
-    override class func tearDown() {
-        GHActions.shared.endGroup()
-        super.tearDown()
-    }
-
     override func run() {
         github.group(name)
         super.run()

--- a/Tests/XSToolingTests/GHTest/GHTestCase.swift
+++ b/Tests/XSToolingTests/GHTest/GHTestCase.swift
@@ -18,6 +18,16 @@ class GHTestCase: XCTestCase {
 #endif
     }
 
+    override class func setUp() {
+        GHActions.shared.group(defaultTestSuite.name)
+        super.setUp()
+    }
+
+    override class func tearDown() {
+        GHActions.shared.endGroup()
+        super.tearDown()
+    }
+
     override func run() {
         github.group(name)
         super.run()


### PR DESCRIPTION
[Grouping log lines](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines)

Creates an expandable group in the log. To create a group, use the group command and specify a title. Anything you print to the log between the group and endgroup commands is nested inside an expandable entry in the log.

```
::group::{title}
::endgroup::
```